### PR TITLE
remove endpoint from resources table

### DIFF
--- a/db_build.sql
+++ b/db_build.sql
@@ -59,8 +59,7 @@ CREATE TABLE IF NOT EXISTS resources (
   url          TEXT        NOT NULL,
   topic_id     INTEGER     NOT NULL     REFERENCES topics(id),
   type_id      INTEGER     NOT NULL     REFERENCES type(id),
-  user_id      INTEGER     NOT NULL     REFERENCES users(id),
-  endpoint     TEXT        UNIQUE
+  user_id      INTEGER     NOT NULL     REFERENCES users(id)
 );
 
 INSERT INTO resources(title, url, topic_id, type_id, user_id) VALUES


### PR DESCRIPTION
Not sure how I managed to get this in there, but is breaking our build and I don't think it's even needed :s

![endpoint](https://cloud.githubusercontent.com/assets/15656538/20770197/c97903ec-b73c-11e6-8519-86e2a337a0a2.png)
